### PR TITLE
Require CAPTCHA on every /start invocation

### DIFF
--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -13,7 +13,14 @@ import contextlib
 
 
 from aiogram import Dispatcher
-from aiogram.types import Message, CallbackQuery, ChatType, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import (
+    CallbackQuery,
+    ChatType,
+    ContentType,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+)
 
 from bot.database.methods import (
     select_max_role_id, create_user, check_role, check_user, get_all_categories, get_all_items,
@@ -39,6 +46,7 @@ from bot.utils import display_name
 from bot.utils.notifications import notify_owner_of_purchase
 from bot.utils.level import get_level_info
 from bot.utils.files import cleanup_item_file
+from bot.utils.security import SecurityManager
 
 PURCHASE_SUCCESS_STATUSES = {'finished', 'confirmed', 'sending', 'paid', 'success'}
 PURCHASE_FAILURE_STATUSES = {'failed', 'refunded', 'expired', 'chargeback', 'cancelled'}
@@ -80,6 +88,150 @@ def build_subcategory_description(parent: str, lang: str) -> str:
     return "\n".join(lines)
 
 
+def _extract_referral_payload(message: Message, user_id: int) -> str | None:
+    if not message.text:
+        return None
+    if not message.text.startswith('/start'):
+        return None
+    payload = message.text[7:].strip()
+    if not payload or payload == str(user_id):
+        return None
+    return payload
+
+
+async def _safe_delete_message(bot, message: Message) -> None:
+    try:
+        await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    except Exception:
+        pass
+
+
+async def _complete_start_flow(message: Message, referral_override: str | None = None) -> None:
+    bot, user_id = await get_bot_user_ids(message)
+
+    TgConfig.STATE[user_id] = None
+
+    owner = select_max_role_id()
+    current_time = datetime.datetime.now()
+    formatted_time = current_time.strftime("%Y-%m-%d %H:%M:%S")
+    referral_id = referral_override if referral_override is not None else _extract_referral_payload(message, user_id)
+    user_role = owner if str(user_id) == EnvKeys.OWNER_ID else 1
+
+    create_user(
+        telegram_id=user_id,
+        registration_date=formatted_time,
+        referral_id=referral_id,
+        role=user_role,
+        username=message.from_user.username,
+    )
+
+    role_data = check_role(user_id)
+    user_db = check_user(user_id)
+
+    user_lang = user_db.language if user_db else None
+    if not user_lang:
+        lang_markup = InlineKeyboardMarkup(row_width=1)
+        lang_markup.add(
+            InlineKeyboardButton('English \U0001F1EC\U0001F1E7', callback_data='set_lang_en'),
+            InlineKeyboardButton('Русский \U0001F1F7\U0001F1FA', callback_data='set_lang_ru'),
+            InlineKeyboardButton('Lietuvi\u0173 \U0001F1F1\U0001F1F9', callback_data='set_lang_lt')
+        )
+        await bot.send_message(
+            user_id,
+            f"{t('en', 'choose_language')} / {t('ru', 'choose_language')} / {t('lt', 'choose_language')}",
+            reply_markup=lang_markup,
+        )
+        await _safe_delete_message(bot, message)
+        return
+
+    balance = user_db.balance if user_db else 0
+    purchases = select_user_items(user_id)
+    markup = main_menu(role_data, TgConfig.REVIEWS_URL, TgConfig.PRICE_LIST_URL, user_lang)
+    text = build_menu_text(message.from_user, balance, purchases, user_lang)
+
+    try:
+        with open(TgConfig.START_PHOTO_PATH, 'rb') as photo:
+            await bot.send_photo(user_id, photo)
+    except Exception:
+        pass
+
+    await bot.send_message(user_id, text, reply_markup=markup)
+
+    if message.content_type == ContentType.TEXT and message.text and message.text.startswith('/start'):
+        await _safe_delete_message(bot, message)
+
+    SecurityManager.clear_challenge(user_id)
+
+
+async def process_security_captcha(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+
+    if SecurityManager.is_user_blocked(user_id):
+        await message.reply(SecurityManager.user_block_message(user_id))
+        TgConfig.STATE[user_id] = None
+        return
+
+    referral = SecurityManager.get_referral(user_id)
+    if SecurityManager.submit_captcha(user_id, message.text or ''):
+        if SecurityManager.is_verified(user_id):
+            TgConfig.STATE[user_id] = None
+            await message.reply("✅ CAPTCHA solved! Logging you in…")
+            await _complete_start_flow(message, referral_override=referral)
+            return
+
+        TgConfig.STATE[user_id] = 'security_photo'
+        await message.reply(
+            "✅ CAPTCHA solved! Please send a recent photo so we can verify it's really you."
+        )
+    else:
+        if SecurityManager.is_user_blocked(user_id):
+            await message.reply(SecurityManager.user_block_message(user_id))
+            TgConfig.STATE[user_id] = None
+            return
+        challenge = SecurityManager.ensure_challenge(user_id)
+        await message.reply(f"❌ Incorrect answer. Try again: {challenge.question}")
+
+
+async def process_security_photo(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+
+    if SecurityManager.is_user_blocked(user_id):
+        await message.reply(SecurityManager.user_block_message(user_id))
+        TgConfig.STATE[user_id] = None
+        return
+
+    if not message.photo:
+        SecurityManager.register_failed_photo(user_id)
+        if SecurityManager.is_user_blocked(user_id):
+            await message.reply(SecurityManager.user_block_message(user_id))
+            TgConfig.STATE[user_id] = None
+        else:
+            await message.reply("❌ Please send a clear photo to complete verification.")
+        return
+
+    SecurityManager.mark_photo_received(user_id)
+    TgConfig.STATE[user_id] = None
+    referral = SecurityManager.pop_referral(user_id)
+    await message.reply("✅ Verification complete! Setting up your account…")
+    await _complete_start_flow(message, referral_override=referral)
+
+
+async def process_security_photo_invalid(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+
+    if SecurityManager.is_user_blocked(user_id):
+        await message.reply(SecurityManager.user_block_message(user_id))
+        TgConfig.STATE[user_id] = None
+        return
+
+    SecurityManager.register_failed_photo(user_id)
+    if SecurityManager.is_user_blocked(user_id):
+        await message.reply(SecurityManager.user_block_message(user_id))
+        TgConfig.STATE[user_id] = None
+    else:
+        await message.reply("❌ A photo is required for verification. Please send a clear image.")
+
+
 def blackjack_hand_value(cards: list[int]) -> int:
     total = sum(cards)
     aces = cards.count(11)
@@ -112,45 +264,30 @@ async def start(message: Message):
     if message.chat.type != ChatType.PRIVATE:
         return
 
-    TgConfig.STATE[user_id] = None
-
-    owner = select_max_role_id()
-    current_time = datetime.datetime.now()
-    formatted_time = current_time.strftime("%Y-%m-%d %H:%M:%S")
-    referral_id = message.text[7:] if message.text[7:] != str(user_id) else None
-    user_role = owner if str(user_id) == EnvKeys.OWNER_ID else 1
-    create_user(telegram_id=user_id, registration_date=formatted_time, referral_id=referral_id, role=user_role,
-                username=message.from_user.username)
-    role_data = check_role(user_id)
-    user_db = check_user(user_id)
-
-
-    user_lang = user_db.language
-    if not user_lang:
-        lang_markup = InlineKeyboardMarkup(row_width=1)
-        lang_markup.add(
-            InlineKeyboardButton('English \U0001F1EC\U0001F1E7', callback_data='set_lang_en'),
-            InlineKeyboardButton('Русский \U0001F1F7\U0001F1FA', callback_data='set_lang_ru'),
-            InlineKeyboardButton('Lietuvi\u0173 \U0001F1F1\U0001F1F9', callback_data='set_lang_lt')
-        )
-        await bot.send_message(user_id,
-                               f"{t('en', 'choose_language')} / {t('ru', 'choose_language')} / {t('lt', 'choose_language')}",
-                               reply_markup=lang_markup)
-        await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    if SecurityManager.is_user_blocked(user_id):
+        await bot.send_message(user_id, SecurityManager.user_block_message(user_id))
+        await _safe_delete_message(bot, message)
         return
 
+    referral_id = _extract_referral_payload(message, user_id)
+    challenge = SecurityManager.refresh_captcha(user_id)
+    if referral_id:
+        challenge.referral = referral_id
 
-    balance = user_db.balance if user_db else 0
-    purchases = select_user_items(user_id)
-    markup = main_menu(role_data, TgConfig.REVIEWS_URL, TgConfig.PRICE_LIST_URL, user_lang)
-    text = build_menu_text(message.from_user, balance, purchases, user_lang)
-    try:
-        with open(TgConfig.START_PHOTO_PATH, 'rb') as photo:
-            await bot.send_photo(user_id, photo)
-    except Exception:
-        pass
-    await bot.send_message(user_id, text, reply_markup=markup)
-    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    TgConfig.STATE[user_id] = 'security_captcha'
+    await bot.send_message(
+        user_id,
+        "🔐 Before we continue, please solve this CAPTCHA to prove you're human.",
+    )
+    await bot.send_message(user_id, f"🧩 What is {challenge.question}?")
+
+    if not SecurityManager.is_verified(user_id):
+        await bot.send_message(
+            user_id,
+            "📸 After answering correctly, send a recent photo/selfie so we can confirm it's you.",
+        )
+
+    await _safe_delete_message(bot, message)
 
 
 async def pavogti(message: Message):
@@ -1586,6 +1723,23 @@ async def set_language(call: CallbackQuery):
 
 
 def register_user_handlers(dp: Dispatcher):
+    dp.register_message_handler(
+        process_security_captcha,
+        lambda m: TgConfig.STATE.get(m.from_user.id) == 'security_captcha',
+        state='*',
+    )
+    dp.register_message_handler(
+        process_security_photo,
+        lambda m: TgConfig.STATE.get(m.from_user.id) == 'security_photo' and bool(m.photo),
+        content_types=['photo'],
+        state='*',
+    )
+    dp.register_message_handler(
+        process_security_photo_invalid,
+        lambda m: TgConfig.STATE.get(m.from_user.id) == 'security_photo' and not m.photo,
+        content_types=ContentType.ANY,
+        state='*',
+    )
     dp.register_message_handler(start,
                                  commands=['start'])
     dp.register_message_handler(purchase_tip_trigger,

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Compatibility layer exposing utility helpers under the bot namespace."""
+from __future__ import annotations
+
+from utils import generate_internal_name, display_name  # noqa: F401
+
+__all__ = [
+    "generate_internal_name",
+    "display_name",
+]

--- a/bot/utils/callback_safe.py
+++ b/bot/utils/callback_safe.py
@@ -1,0 +1,2 @@
+"""Proxy module for callback safe helpers."""
+from utils.callback_safe import *  # noqa: F401,F403

--- a/bot/utils/files.py
+++ b/bot/utils/files.py
@@ -1,0 +1,2 @@
+"""Proxy module for backwards compatibility."""
+from utils.files import *  # noqa: F401,F403

--- a/bot/utils/level.py
+++ b/bot/utils/level.py
@@ -1,0 +1,2 @@
+"""Proxy module for level helpers."""
+from utils.level import *  # noqa: F401,F403

--- a/bot/utils/notifications.py
+++ b/bot/utils/notifications.py
@@ -1,0 +1,2 @@
+"""Proxy module exposing notification helpers under the bot namespace."""
+from utils.notifications import *  # noqa: F401,F403

--- a/bot/utils/safe_sender.py
+++ b/bot/utils/safe_sender.py
@@ -1,0 +1,2 @@
+"""Proxy module for safe sender helpers."""
+from utils.safe_sender import *  # noqa: F401,F403

--- a/bot/utils/security.py
+++ b/bot/utils/security.py
@@ -1,0 +1,256 @@
+"""Security utilities for user verification and IP monitoring."""
+
+from __future__ import annotations
+
+import random
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Optional
+
+from bot.logger_mesh import logger
+
+
+@dataclass
+class VerificationChallenge:
+    """Represents an onboarding challenge for a Telegram user."""
+
+    question: str
+    answer: str
+    referral: Optional[str] = None
+    captcha_verified: bool = False
+    photo_verified: bool = False
+    attempts: int = 0
+    last_failures: Deque[float] = field(default_factory=lambda: deque(maxlen=10))
+    created_at: float = field(default_factory=time.time)
+
+
+class SecurityManager:
+    """Centralised security helpers for the bot and web services."""
+
+    _user_challenges: Dict[int, VerificationChallenge] = {}
+    _verified_users: set[int] = set()
+    _blocked_users: Dict[int, float] = {}
+
+    _ip_requests: Dict[str, Deque[float]] = defaultdict(lambda: deque(maxlen=200))
+    _ip_failures: Dict[str, Deque[float]] = defaultdict(lambda: deque(maxlen=50))
+    _blocked_ips: Dict[str, float] = {}
+
+    captcha_attempt_limit: int = 3
+    photo_attempt_limit: int = 2
+    block_duration: float = 15 * 60  # 15 minutes
+
+    ip_rate_window: float = 60.0
+    ip_rate_limit: int = 30
+    ip_failure_limit: int = 6
+    ip_failure_window: float = 10 * 60.0
+    ip_anomaly_threshold: int = 120
+
+    @staticmethod
+    def _generate_captcha() -> tuple[str, str]:
+        left = random.randint(10, 99)
+        right = random.randint(1, 9)
+        if random.random() > 0.5:
+            question = f"{left} + {right}"
+            answer = str(left + right)
+        else:
+            question = f"{left} - {right}"
+            answer = str(left - right)
+        return question, answer
+
+    @classmethod
+    def ensure_challenge(cls, user_id: int, referral: Optional[str] = None) -> VerificationChallenge:
+        challenge = cls._user_challenges.get(user_id)
+        if not challenge:
+            question, answer = cls._generate_captcha()
+            challenge = VerificationChallenge(question=question, answer=answer, referral=referral)
+            cls._user_challenges[user_id] = challenge
+            logger.info("Created security challenge for user %s", user_id)
+        elif referral and not challenge.referral:
+            challenge.referral = referral
+        return challenge
+
+    @classmethod
+    def refresh_captcha(cls, user_id: int) -> VerificationChallenge:
+        question, answer = cls._generate_captcha()
+        challenge = cls._user_challenges.setdefault(
+            user_id, VerificationChallenge(question=question, answer=answer)
+        )
+        challenge.question = question
+        challenge.answer = answer
+        challenge.captcha_verified = False
+        logger.debug("Refreshed captcha for user %s", user_id)
+        return challenge
+
+    @classmethod
+    def submit_captcha(cls, user_id: int, answer: str) -> bool:
+        challenge = cls._user_challenges.get(user_id)
+        if not challenge:
+            challenge = cls.refresh_captcha(user_id)
+        if cls.is_user_blocked(user_id):
+            return False
+        normalized = answer.strip().lower()
+        if normalized == challenge.answer.lower():
+            challenge.captcha_verified = True
+            challenge.attempts = 0
+            challenge.last_failures.clear()
+            logger.info("User %s solved captcha", user_id)
+            return True
+        challenge.attempts += 1
+        now = time.time()
+        challenge.last_failures.append(now)
+        logger.warning(
+            "User %s failed captcha attempt %s", user_id, challenge.attempts
+        )
+        if challenge.attempts >= cls.captcha_attempt_limit:
+            cls.block_user(user_id, reason="too_many_captcha_failures")
+        else:
+            cls.refresh_captcha(user_id)
+        return False
+
+    @classmethod
+    def mark_photo_received(cls, user_id: int) -> bool:
+        challenge = cls._user_challenges.get(user_id)
+        if not challenge:
+            challenge = cls.refresh_captcha(user_id)
+        if cls.is_user_blocked(user_id):
+            return False
+        challenge.photo_verified = True
+        challenge.attempts = 0
+        cls._verified_users.add(user_id)
+        logger.info("User %s passed photo verification", user_id)
+        return True
+
+    @classmethod
+    def register_failed_photo(cls, user_id: int) -> None:
+        challenge = cls._user_challenges.get(user_id)
+        if not challenge:
+            challenge = cls.refresh_captcha(user_id)
+        challenge.attempts += 1
+        logger.warning(
+            "User %s submitted invalid verification photo (attempt %s)",
+            user_id,
+            challenge.attempts,
+        )
+        if challenge.attempts >= cls.photo_attempt_limit:
+            cls.block_user(user_id, reason="invalid_photo_attempts")
+
+    @classmethod
+    def clear_challenge(cls, user_id: int) -> None:
+        cls._user_challenges.pop(user_id, None)
+
+    @classmethod
+    def is_verified(cls, user_id: int) -> bool:
+        if cls.is_user_blocked(user_id):
+            return False
+        challenge = cls._user_challenges.get(user_id)
+        if challenge and challenge.captcha_verified and challenge.photo_verified:
+            cls._verified_users.add(user_id)
+        return user_id in cls._verified_users
+
+    @classmethod
+    def get_referral(cls, user_id: int) -> Optional[str]:
+        challenge = cls._user_challenges.get(user_id)
+        return challenge.referral if challenge else None
+
+    @classmethod
+    def pop_referral(cls, user_id: int) -> Optional[str]:
+        challenge = cls._user_challenges.get(user_id)
+        if not challenge:
+            return None
+        referral = challenge.referral
+        challenge.referral = None
+        return referral
+
+    @classmethod
+    def block_user(cls, user_id: int, reason: str, duration: Optional[float] = None) -> None:
+        expiry = time.time() + (duration or cls.block_duration)
+        cls._blocked_users[user_id] = expiry
+        logger.error(
+            "Blocking user %s for %ss due to %s",
+            user_id,
+            int(expiry - time.time()),
+            reason,
+        )
+
+    @classmethod
+    def is_user_blocked(cls, user_id: int) -> bool:
+        expiry = cls._blocked_users.get(user_id)
+        if not expiry:
+            return False
+        if expiry <= time.time():
+            cls._blocked_users.pop(user_id, None)
+            return False
+        return True
+
+    @classmethod
+    def user_block_message(cls, user_id: int) -> str:
+        expiry = cls._blocked_users.get(user_id)
+        if not expiry:
+            return "🚫 Access denied."
+        remaining = max(int(expiry - time.time()), 0)
+        minutes, seconds = divmod(remaining, 60)
+        duration = f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
+        return (
+            "🚫 Due to suspicious activity, access is temporarily blocked. "
+            f"Please try again in {duration}."
+        )
+
+    @classmethod
+    def record_ip_request(cls, ip: str) -> tuple[bool, Optional[str]]:
+        now = time.time()
+        queue = cls._ip_requests[ip]
+        queue.append(now)
+        while queue and now - queue[0] > cls.ip_rate_window:
+            queue.popleft()
+        if len(queue) > cls.ip_anomaly_threshold:
+            cls.block_ip(ip, reason="anomalous_request_rate", duration=cls.block_duration * 2)
+            return False, "anomaly"
+        if len(queue) > cls.ip_rate_limit:
+            return False, "rate_limit"
+        return True, None
+
+    @classmethod
+    def block_ip(cls, ip: str, reason: str, duration: Optional[float] = None) -> None:
+        expiry = time.time() + (duration or cls.block_duration)
+        cls._blocked_ips[ip] = expiry
+        logger.error("Blocked IP %s for %ss due to %s", ip, int(expiry - time.time()), reason)
+
+    @classmethod
+    def is_ip_blocked(cls, ip: str) -> bool:
+        expiry = cls._blocked_ips.get(ip)
+        if not expiry:
+            return False
+        if expiry <= time.time():
+            cls._blocked_ips.pop(ip, None)
+            return False
+        return True
+
+    @classmethod
+    def record_ip_failure(cls, ip: str, reason: str) -> None:
+        now = time.time()
+        failure_log = cls._ip_failures[ip]
+        failure_log.append(now)
+        while failure_log and now - failure_log[0] > cls.ip_failure_window:
+            failure_log.popleft()
+        logger.warning(
+            "Security failure for IP %s: %s (%s recent failures)",
+            ip,
+            reason,
+            len(failure_log),
+        )
+        if len(failure_log) >= cls.ip_failure_limit:
+            cls.block_ip(ip, reason=f"repeated_failures:{reason}")
+
+    @classmethod
+    def cleanup(cls) -> None:
+        now = time.time()
+        for user_id, expiry in list(cls._blocked_users.items()):
+            if expiry <= now:
+                cls._blocked_users.pop(user_id, None)
+        for ip, expiry in list(cls._blocked_ips.items()):
+            if expiry <= now:
+                cls._blocked_ips.pop(ip, None)
+
+
+__all__ = ["SecurityManager", "VerificationChallenge"]


### PR DESCRIPTION
## Summary
- refresh and send a new CAPTCHA challenge on every /start message while preserving referral payloads
- immediately resume onboarding for returning verified users after solving the CAPTCHA, keeping photo verification for new users

## Testing
- python -m compileall bot/utils/security.py bot/handlers/user/main.py bot/ipn_server.py

------
https://chatgpt.com/codex/tasks/task_e_68ddeb480d408332a17d950e6a65ce84